### PR TITLE
Refine page-specific styling structure

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -45,6 +45,11 @@
   box-shadow: var(--shadow);
 }
 
+.main-nav a,
+.tel {
+  font-family: var(--font-sans), sans-serif;
+}
+
 .header-contacts {
   display: flex;
   gap: 8px;
@@ -59,12 +64,17 @@
   font-weight: 700;
   text-decoration: none;
   line-height: 1;
-  font-family: var(--font-sans);
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .tel:hover {
   background: var(--accent);
   color: #111;
+}
+
+.tel:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.6);
 }
 
 /* navigația rămâne la dreapta */
@@ -74,10 +84,22 @@
   margin-left: 18px;
   padding: 6px 8px;
   border-radius: 8px;
+  opacity: 0.95;
+  transition: background-color 0.2s ease, opacity 0.2s ease;
 }
 
 .main-nav a.active {
   background: rgba(255, 255, 255, .18);
+}
+
+.main-nav a:hover {
+  opacity: 1;
+}
+
+.main-nav a:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 2px;
+  opacity: 1;
 }
 
 /* pe mobil, ascundem telefoanele ca să nu aglomerăm header-ul */
@@ -85,4 +107,11 @@
   .header-contacts {
     display: none;
   }
+}
+
+.site-footer {
+  background: var(--bg-alt);
+  padding: 22px 0;
+  color: #556;
+  font-size: 0.92rem;
 }

--- a/src/app/pages/acasa.page.html
+++ b/src/app/pages/acasa.page.html
@@ -1,6 +1,6 @@
 <!-- HERO cu imagine și text scurt -->
 <section class="hero">
-  <div class="container inner">
+  <div class="container hero__inner">
     <h1>Bine ați venit la Centrul de Îngrijire și Asistență pentru Persoane Adulte cu Dizabilități "People for
       People" </h1>
     <p class="lead">
@@ -17,10 +17,10 @@
       vieții, transformăm centrul într-un loc unde fiecare adult se simte respectat, încurajat și parte dintr-o
       comunitate.
     </p>
-    <p style="margin-top: 16px">
+    <div class="hero__actions">
       <a routerLink="/contact" class="btn btn--primary">Programează o vizită</a>
-      <a routerLink="/despre-noi" class="btn btn--ghost" style="margin-left: 8px">Despre noi</a>
-    </p>
+      <a routerLink="/despre-noi" class="btn btn--ghost">Despre noi</a>
+    </div>
   </div>
 </section>
 
@@ -28,7 +28,7 @@
 <section class="section section--alt">
   <div class="container">
     <h2>De ce să ne alegeți</h2>
-    <div class="grid grid--3" style="margin-top: 14px">
+    <div class="grid grid--3 reasons-grid">
       <div class="card">
         <h3>Îngrijire personalizată</h3>
         <p class="lead">
@@ -52,7 +52,7 @@
 <!-- Mică galerie (pozele clientului) -->
 <section class="section">
   <div class="container">
-    <div class="grid grid--3 gallery" style="margin-top: 14px">
+    <div class="grid grid--3 home-gallery">
       <img
         src="/img/care-01.jpg"
         alt="Îngrijire într-un mediu cald"
@@ -77,8 +77,8 @@
     <p class="lead">
       Suntem aici să răspundem la întrebări și să găsim împreună soluția potrivită.
     </p>
-    <p style="margin-top: 10px">
+    <div class="cta__actions">
       <a routerLink="/contact" class="btn btn--primary">Contact rapid</a>
-    </p>
+    </div>
   </div>
 </section>

--- a/src/app/pages/acasa.page.scss
+++ b/src/app/pages/acasa.page.scss
@@ -1,0 +1,53 @@
+:host {
+  display: block;
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  color: #0f172a;
+  background: linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0),
+      rgba(255, 255, 255, 0.95)
+    ),
+    url('/img/hero.jpg') center/cover no-repeat;
+
+  &__inner {
+    padding-top: clamp(140px, 25vw, 220px);
+    padding-bottom: clamp(40px, 12vw, 80px);
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 1rem;
+  }
+}
+
+.reasons-grid {
+  margin-top: 1rem;
+}
+
+.home-gallery {
+  margin-top: 1rem;
+
+  img {
+    width: 100%;
+    height: clamp(200px, 32vw, 260px);
+    object-fit: cover;
+    border-radius: 12px;
+    box-shadow: var(--shadow);
+  }
+}
+
+.cta__actions {
+  margin-top: 0.75rem;
+}
+
+@media (max-width: 599px) {
+  .hero__inner {
+    padding-top: 120px;
+  }
+}

--- a/src/app/pages/contact.page.html
+++ b/src/app/pages/contact.page.html
@@ -1,9 +1,9 @@
 <section class="section">
   <div class="container">
     <h1>Contact</h1>
-    <div class="grid grid--2" style="margin-top: 14px">
+    <div class="grid grid--2 contact-layout">
       <div>
-        <div class="card" style="margin-bottom: 18px">
+        <div class="card contact-details">
           <h2>Detalii</h2>
           <p><strong>Adresă:</strong> Sat Robești, Nr. 9, comuna Pârscov, jud. Buzău</p>
           <p><strong>Telefon fix:</strong> <a href="tel:+40338405999">0338 405 999</a></p>
@@ -16,34 +16,46 @@
           </p>
         </div>
 
-        <div class="card">
+        <div class="card contact-form">
           <h3>Trimite-ne un mesaj</h3>
-          <form name="contact" method="POST" data-netlify="true" netlify-honeypot="bot-field">
+          <form
+            class="contact-form__form"
+            name="contact"
+            method="POST"
+            data-netlify="true"
+            netlify-honeypot="bot-field"
+          >
             <input type="hidden" name="form-name" value="contact" />
             <p hidden>
               <label>Nu completa: <input name="bot-field" /></label>
             </p>
 
-            <label>Nume<br /><input type="text" name="nume" required /></label><br /><br />
-            <label>Email<br /><input type="email" name="email" required /></label><br /><br />
-            <label>Mesaj<br /><textarea name="mesaj" rows="5" required></textarea></label
-            ><br /><br />
-            <button class="btn btn--primary" type="submit">Trimite</button>
+            <label class="contact-form__field">
+              <span>Nume</span>
+              <input type="text" name="nume" required />
+            </label>
+            <label class="contact-form__field">
+              <span>Email</span>
+              <input type="email" name="email" required />
+            </label>
+            <label class="contact-form__field">
+              <span>Mesaj</span>
+              <textarea name="mesaj" rows="5" required></textarea>
+            </label>
+            <button class="btn btn--primary contact-form__submit" type="submit">Trimite</button>
           </form>
         </div>
       </div>
 
-      <div class="card">
+      <div class="card contact-map">
         <h2>Locație</h2>
         <iframe
           src="https://www.google.com/maps/embed?pb=!4v1758002655632!6m8!1m7!1s9YXqv4cGn_bWqkhoUWu1_w!2m2!1d45.29696074038792!2d26.60006441005294!3f13.189691456289857!4f1.229934100244364!5f0.8097055968225422"
-          width="100%"
-          height="420"
-          style="border: 0; border-radius: 12px"
+          class="contact-map__embed"
           allowfullscreen
           loading="lazy"
         ></iframe>
-        <p style="margin-top: 10px">
+        <div class="contact-map__actions">
           <a
             class="btn btn--ghost"
             href="https://maps.app.goo.gl/i9fkSeRaEFRp1zw56"
@@ -51,7 +63,7 @@
             rel="noopener"
             >Deschide în Google Maps</a
           >
-        </p>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/pages/contact.page.scss
+++ b/src/app/pages/contact.page.scss
@@ -1,0 +1,81 @@
+:host {
+  display: block;
+}
+
+.contact-layout {
+  margin-top: 1rem;
+  align-items: start;
+}
+
+.contact-details {
+  margin-bottom: 1.25rem;
+}
+
+.contact-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.contact-form__form {
+  display: grid;
+  gap: 1rem;
+}
+
+.contact-form__field {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--muted);
+  font-family: var(--font-sans), sans-serif;
+  font-weight: 600;
+}
+
+.contact-form__field span {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.contact-form__field input,
+.contact-form__field textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #d4d4d8;
+  border-radius: 10px;
+  background: #fff;
+  font: inherit;
+  resize: vertical;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.contact-form__field input:focus,
+.contact-form__field textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(26, 188, 156, 0.2);
+}
+
+.contact-form__submit {
+  justify-self: start;
+}
+
+.contact-map {
+  display: grid;
+  gap: 1rem;
+}
+
+.contact-map__embed {
+  width: 100%;
+  min-height: 26rem;
+  border: 0;
+  border-radius: 12px;
+}
+
+.contact-map__actions {
+  margin-top: 0.25rem;
+}
+
+@media (max-width: 780px) {
+  .contact-layout {
+    margin-top: 1.5rem;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -33,8 +33,6 @@ body {
   background: var(--bg);
 }
 
-.site-header .brand,
-.site-header nav a,
 .btn,
 .small {
   font-family: var(--font-sans), sans-serif;
@@ -126,51 +124,9 @@ h2 {
   background: #fff;
 }
 
-nav a {
-  color: #fff;
-  text-decoration: none;
-  margin-left: 18px;
-  padding: 6px 4px;
-  border-radius: 8px;
-  opacity: 0.95;
-}
-
-nav a.active {
-  background: rgba(255, 255, 255, 0.18);
-}
-
-/* ===== Hero ===== */
-.hero {
-  position: relative;
-  overflow: hidden;
-  color: #0f172a;
-  background: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.95)),
-  url('/img/hero.jpg') center/cover no-repeat;
-}
-
-.hero .inner {
-  padding-top: 200px;
-}
-
-/* ===== Imagery ===== */
 .img-cover {
   width: 100%;
   height: 100%;
   object-fit: cover;
   border-radius: var(--radius);
-}
-
-.gallery img {
-  width: 100%;
-  height: 220px;
-  object-fit: cover;
-  border-radius: 12px;
-}
-
-/* ===== Footer ===== */
-.site-footer {
-  background: var(--bg-alt);
-  padding: 22px 0;
-  color: #556;
-  font-size: 0.92rem;
 }


### PR DESCRIPTION
## Summary
- simplified the global stylesheet to keep shared tokens, layout utilities and button/card rules while moving header nav and footer styling into the app component
- scoped the homepage hero, reasons grid and gallery styles inside `acasa.page.scss` and removed inline attributes from the template
- refreshed the contact page markup and introduced dedicated SCSS for the form and map blocks to replace inline styles and improve form controls

## Testing
- npm run lint *(fails: Angular project has no lint target configured)*
- npm run build *(fails: Google Fonts inlining request returns HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c9dfcc1c8326832c2e86a3c721ca