### PR TITLE
Revitalize about and contact pages

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -94,5 +94,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -1,3 +1,14 @@
+:host {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  flex: 1;
+  display: block;
+}
+
 .site-header {
   position: sticky;
   top: 0;

--- a/src/app/pages/contact.page.html
+++ b/src/app/pages/contact.page.html
@@ -1,4 +1,4 @@
-<section class="section">
+<section class="section contact-page">
   <div class="container">
     <h1>Contact</h1>
     <div class="grid grid--2 contact-layout">
@@ -50,10 +50,14 @@
       <div class="card contact-map">
         <h2>Locație</h2>
         <iframe
-          src="https://www.google.com/maps/embed?pb=!4v1758002655632!6m8!1m7!1s9YXqv4cGn_bWqkhoUWu1_w!2m2!1d45.29696074038792!2d26.60006441005294!3f13.189691456289857!4f1.229934100244364!5f0.8097055968225422"
           class="contact-map__embed"
-          allowfullscreen
+          src="https://www.google.com/maps/embed?pb=!4v1758051050269!6m8!1m7!1s5CbXyk6UTs5IROy_h3xdNQ!2m2!1d45.2969686421958!2d26.60019245649253!3f354.68533785337763!4f1.3880148919519115!5f0.7820865974627469"
+          width="600"
+          height="450"
+          style="border:0;"
+          allowfullscreen=""
           loading="lazy"
+          referrerpolicy="no-referrer-when-downgrade"
         ></iframe>
         <div class="contact-map__actions">
           <a

--- a/src/app/pages/contact.page.scss
+++ b/src/app/pages/contact.page.scss
@@ -2,6 +2,10 @@
   display: block;
 }
 
+.contact-page {
+  padding-top: clamp(150px, 22vw, 220px);
+}
+
 .contact-layout {
   margin-top: 1rem;
   align-items: start;
@@ -75,6 +79,10 @@
 }
 
 @media (max-width: 780px) {
+  .contact-page {
+    padding-top: 130px;
+  }
+
   .contact-layout {
     margin-top: 1.5rem;
   }

--- a/src/app/pages/despre-noi.page.html
+++ b/src/app/pages/despre-noi.page.html
@@ -1,46 +1,121 @@
-<section class="section">
-  <div class="container">
-    <h1>Povestea noastră</h1>
+<section class="about-hero">
+  <div class="container about-hero__inner">
+    <p class="about-hero__kicker">Despre noi</p>
+    <h1>Partenerul de încredere pentru persoanele vulnerabile</h1>
     <p class="lead">
-      Asociația People for People a luat ființă în 2017 pentru a sprijini persoanele vulnerabile.
-      Din 2021 suntem acreditați de Ministerul Muncii și Solidarității Sociale – confirmare a
-      profesionalismului și calității serviciilor oferite.
+      Asociația People for People s-a născut din dorința de a oferi siguranță, demnitate și sprijin continuu
+      persoanelor adulte cu dizabilități. Construim un mediu cald, în care fiecare beneficiar și familie
+      găsește înțelegere, profesionalism și soluții adaptate nevoilor lor.
     </p>
   </div>
 </section>
 
-<section class="section section--alt">
+<section class="section about-story">
   <div class="container grid grid--2">
-    <div class="card">
-      <h2>Misiunea noastră</h2>
+    <div class="about-story__content">
+      <h2>Povestea noastră</h2>
       <p>
-        Să aducem binele mai aproape de oameni, oferind servicii de îngrijire și asistență care
-        îmbunătățesc calitatea vieții beneficiarilor și liniștea familiilor lor.
+        Asociația People for People a luat ființă în anul <strong>2017</strong>, din dorința de a sprijini persoanele
+        vulnerabile și familiile lor. Ne-am propus încă de la început să fim mai mult decât un centru de
+        îngrijire: să fim o casă în care oamenii se simt respectați, ascultați și încurajați să meargă
+        mai departe.
+      </p>
+      <p>
+        În <strong>2021</strong>, organizația noastră a primit acreditarea de la Ministerul Muncii și Solidarității Sociale,
+        o confirmare a calității serviciilor pe care le oferim zi de zi. Continuăm să dezvoltăm programe,
+        activități și parteneriate prin care beneficiarii noștri primesc sprijin specializat și acces la
+        resurse esențiale.
+      </p>
+      <p>
+        De la început și până astăzi, rămânem fideli misiunii noastre: să oferim un sprijin real adulților cu
+        dizabilități și familiilor lor și să fim un reper de profesionalism în comunitate.
       </p>
     </div>
-    <div class="card">
-      <h2>Valorile noastre</h2>
+    <div class="card about-story__highlights">
+      <h3>Repere importante</h3>
       <ul>
-        <li>Respect pentru fiecare persoană</li>
-        <li>Profesionalism în toate serviciile</li>
-        <li>Empatie și înțelegere</li>
-        <li>Colaborare cu familiile și comunitatea</li>
+        <li><strong>2017:</strong> Înființarea asociației People for People și primele programe de suport comunitar.</li>
+        <li>
+          <strong>2021:</strong> Acreditare din partea Ministerului Muncii și Solidarității Sociale pentru calitatea
+          serviciilor noastre.
+        </li>
+        <li><strong>Astăzi:</strong> Rețea de profesioniști dedicați și programe personalizate pentru fiecare beneficiar.</li>
       </ul>
     </div>
   </div>
 </section>
 
-<section class="section">
+<section class="section section--alt about-mission">
   <div class="container grid grid--2">
-    <div>
-      <h2>Echipa</h2>
-      <p>Asistenți medicali, infirmieri, psiholog, ergoterapeuți, asistent social.</p>
+    <div class="card about-mission__mission">
+      <h2>Misiunea noastră</h2>
+      <p>
+        Misiunea noastră este să fim alături de fiecare persoană aflată în dificultate, oferindu-i servicii de
+        îngrijire, reabilitare și consiliere adaptate nevoilor sale. Printr-o abordare integrată, asigurăm
+        monitorizarea medicală, sprijin emoțional și activități care redau încrederea în propriile forțe.
+      </p>
+      <p>
+        Ne implicăm activ în comunitate, colaborăm cu familiile și instituțiile partenere și punem accent pe
+        comunicare transparentă. Credem că doar împreună putem construi un parcurs stabil și demn pentru cei pe
+        care îi îngrijim.
+      </p>
     </div>
-    <img
-      class="img-cover"
-      src="/img/illustration-01.jpg"
-      alt="Ilustrație îngrijire"
-      loading="lazy"
-    />
+    <div class="card about-values">
+      <h2>Valorile noastre</h2>
+      <ul class="about-values__list">
+        <li>
+          <strong>Respect:</strong> fiecare persoană este tratată cu demnitate, indiferent de situația în care se află.
+        </li>
+        <li>
+          <strong>Profesionalism:</strong> servicii sigure și bine documentate, livrate de specialiști cu experiență.
+        </li>
+        <li>
+          <strong>Empatie:</strong> ascultăm cu răbdare și răspundem cu blândețe, oferind un mediu în care oamenii se simt în siguranță.
+        </li>
+        <li>
+          <strong>Colaborare:</strong> lucrăm alături de familii și comunitate pentru soluții durabile și personalizate.
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="section about-team">
+  <div class="container">
+    <h2>Echipa noastră multidisciplinară</h2>
+    <p class="lead">
+      Echipa Asociației People for People este formată din specialiști dedicați, care lucrează împreună în interesul
+      beneficiarilor. În fiecare zi, combinăm expertiza medicală cu suport emoțional și social pentru a oferi
+      îngrijire completă.
+    </p>
+    <div class="grid grid--3 about-team__grid">
+      <div class="card">
+        <h3>Asistenți medicali</h3>
+        <p>Monitorizează starea de sănătate, coordonează tratamentele și mențin legătura cu medicii specialiști.</p>
+      </div>
+      <div class="card">
+        <h3>Infirmieri</h3>
+        <p>Oferă sprijin în activitățile zilnice, ajutând fiecare beneficiar să se simtă confortabil și în siguranță.</p>
+      </div>
+      <div class="card">
+        <h3>Psiholog</h3>
+        <p>Asigură consiliere și suport emoțional, pentru ca beneficiarii să își mențină echilibrul și motivația.</p>
+      </div>
+      <div class="card">
+        <h3>Asistent social</h3>
+        <p>Ghidează familiile și beneficiarii în relația cu instituțiile și resursele comunității, facilitând accesul la sprijin.</p>
+      </div>
+      <div class="card">
+        <h3>Ergoterapeuți &amp; parteneri</h3>
+        <p>Organizează activități care încurajează autonomia, integrarea socială și recuperarea fiecărui beneficiar.</p>
+      </div>
+      <div class="card about-team__collaboration">
+        <h3>Împreună pentru familie</h3>
+        <p>
+          Suntem o echipă unită cu un scop comun: să fim aproape de oameni și să oferim sprijin personalizat familiilor
+          care au nevoie de noi.
+        </p>
+      </div>
+    </div>
   </div>
 </section>

--- a/src/app/pages/despre-noi.page.scss
+++ b/src/app/pages/despre-noi.page.scss
@@ -1,0 +1,134 @@
+:host {
+  display: block;
+  --about-hero-image: url('/img/care-03.jpg');
+}
+
+.about-hero {
+  position: relative;
+  overflow: hidden;
+  color: #0f172a;
+  background: linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.4),
+      rgba(255, 255, 255, 0.92)
+    ),
+    var(--about-hero-image) center/cover no-repeat;
+
+  &__inner {
+    position: relative;
+    z-index: 1;
+    max-width: 720px;
+    padding-top: clamp(180px, 28vw, 240px);
+    padding-bottom: clamp(70px, 18vw, 130px);
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  &__kicker {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+    color: var(--accent);
+    margin: 0;
+  }
+
+  .lead {
+    color: #334155;
+  }
+}
+
+.about-story__content,
+.about-mission__mission {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.about-story__highlights {
+  display: grid;
+  gap: 1rem;
+}
+
+.about-story__highlights ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.about-story__highlights li {
+  position: relative;
+  padding-left: 1.75rem;
+  color: #1f2937;
+}
+
+.about-story__highlights li::before {
+  content: '';
+  position: absolute;
+  top: 0.45rem;
+  left: 0.25rem;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 3px rgba(251, 192, 45, 0.25);
+}
+
+.about-story__highlights strong {
+  color: var(--primary-700);
+}
+
+.about-values__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.about-values__list li {
+  border-left: 4px solid var(--primary);
+  padding-left: 1rem;
+  color: #1f2937;
+}
+
+.about-values__list strong {
+  display: block;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.2rem;
+  color: var(--primary-700);
+}
+
+.about-team {
+  background: #fff;
+}
+
+.about-team .lead {
+  max-width: 760px;
+  margin-bottom: 1.5rem;
+}
+
+.about-team__grid {
+  margin-top: 1rem;
+}
+
+.about-team__grid .card {
+  display: grid;
+  gap: 0.5rem;
+  padding: 24px;
+}
+
+.about-team__collaboration {
+  background: var(--bg-brand);
+  border: 1px solid rgba(26, 188, 156, 0.15);
+}
+
+@media (max-width: 780px) {
+  .about-hero__inner {
+    padding-top: 150px;
+    padding-bottom: 80px;
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,10 @@
   <head>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600;700&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600;700&family=Source+Sans+3:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    >
 
     <meta charset="utf-8" />
     <title>CentruAsistentaBatrani</title>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -11,8 +11,7 @@
   --shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
   --radius: 14px;
 
-  //--font-sans: Inter, system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
-  --font-sans: "Lora", "Times New Roman", Times, Georgia, serif;
+  --font-sans: "Source Sans 3", Inter, "Segoe UI", Roboto, Arial, sans-serif;
   --font-serif: "Lora", "Times New Roman", Times, Georgia, serif;
 }
 
@@ -28,9 +27,10 @@ body {
 
 body {
   margin: 0;
-  font-family: var(--font-serif), serif;
+  font-family: var(--font-sans), sans-serif;
   color: var(--text);
   background: var(--bg);
+  line-height: 1.6;
 }
 
 .btn,
@@ -79,6 +79,17 @@ body {
 }
 
 /* ===== Tipografie ===== */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-serif), serif;
+  font-weight: 600;
+  color: #0f172a;
+}
+
 h1 {
   font-size: clamp(28px, 3.2vw, 42px);
   line-height: 1.15;
@@ -86,13 +97,18 @@ h1 {
 }
 
 h2 {
-  font-size: clamp(22px, 2.4vw, 28px);
+  font-size: clamp(22px, 2.4vw, 32px);
   margin: 0 0 12px;
 }
 
+h3 {
+  font-size: clamp(20px, 2vw, 26px);
+  margin: 0 0 10px;
+}
+
 .lead {
-  font-size: 14px;
-  line-height: 1;
+  font-size: clamp(1rem, 0.7vw + 0.95rem, 1.15rem);
+  line-height: 1.7;
   color: var(--muted);
 }
 


### PR DESCRIPTION
## Summary
- update the global typography to use Source Sans 3 for body text and keep Lora for headings for a more professional tone
- make the application shell stretch to the viewport height so the footer stays anchored to the bottom
- redesign the "Despre noi" page with a hero banner, detailed story/mission sections, value highlights and team cards, including styling hooks for a custom background image
- adjust the contact page spacing, drop the new map iframe and move the layout below the floating logo

## Testing
- `npm run lint` *(fails: lint target is not configured in the Angular workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cf5d8ce8832680beacc27f18ec4d